### PR TITLE
Send SOA for referrals ending with .eth or ._eth

### DIFF
--- a/lib/handover.js
+++ b/lib/handover.js
@@ -51,7 +51,7 @@ class Plugin {
               // TODO: plugin should have ephemeral DNSSEC keys.
               // We should return that here, signed by HNS root ZSK.
             } else {
-              return this.sendSOA(name);
+              return this.sendSOA();
             }
           } else {
             data = await this.ethereum.resolveDnsFromEns(name, type);
@@ -63,7 +63,7 @@ class Plugin {
             // TODO: plugin should have ephemeral DNSSEC keys.
             // We should return that here, signed by HNS root ZSK.
           } else {
-            return this.sendSOA(name);
+            return this.sendSOA();
           }
           break;
       }
@@ -76,6 +76,7 @@ class Plugin {
       if (!res.authority.length)
         return res;
 
+      let hasEnsReferral = false;
       // Check NS records for referals to TLDs `.eth` and `._eth`
       for (const rr of res.authority) {
         if (rr.type !== wire.types.NS)
@@ -84,11 +85,14 @@ class Plugin {
         // Look up the ENS resolver specified in the NS record
         // and query it for the user's original request
         if (rr.data.ns.slice(-5) === '.eth.') {
+          hasEnsReferral = true;
+
           // If the recursive is being minimal, don't look up the name.
           // Send the SOA back and get the full query from the recursive .
           if (labels.length < 2) {
-            return this.sendSOA(name);
+            return this.sendSOA();
           }
+
           this.logger.debug(
             'Intercepted referral to .eth: %s %s -> NS: %s',
             name,
@@ -106,10 +110,12 @@ class Plugin {
         // address specified in the NS record, and query it for
         // the user's original request
         if (rr.data.ns.slice(-6) === '._eth.') {
+          hasEnsReferral = true;
+
           // If the recursive is being minimal, don't look up the name.
           // Send the SOA back and get the full query from the recursive .
           if (labels.length < 2) {
-            return this.sendSOA(name);
+            return this.sendSOA();
           }
           this.logger.debug(
             'Intercepted referral to ._eth: %s %s -> %s NS: %s',
@@ -128,8 +134,16 @@ class Plugin {
 
       // If the Ethereum stuff came up empty, return the
       // HNS root server response unmodified.
-      if (!data || data.length === 0)
+      if (!data || data.length === 0) {
+        // never send referrals that end with .eth or ._eth
+        // since recursive may cache these referrals causing a servfail
+        // for future lookups
+        if (hasEnsReferral) {
+          return this.sendSOA();
+        }
+
         return res;
+      }
 
       // If we did get an answer from Ethereum, mark the response
       // as authoritative and insert the new answer.
@@ -191,33 +205,11 @@ class Plugin {
     return res;
   }
 
-  // Copy from the end of hsd's server.response() to send
-  // SOA-only when we don't have / don't want to answer.
-  async sendSOA(name) {
-    let serial = 0;
-    const date = new Date();
-    serial += date.getUTCFullYear() * 1e6;
-    serial += (date.getUTCMonth() + 1) * 1e4;
-    serial += date.getUTCDate() * 1e2;
-    serial += date.getUTCHours();
-
-    const rd = new wire.SOARecord();
-    rd.ns = name;
-    rd.mbox = name;
-    rd.serial = serial;
-    rd.refresh = 1800;
-    rd.retry = 900;
-    rd.expire = 604800;
-    rd.minttl = 86400;
-
-    const rr = new wire.Record();
-    rr.name = name;
-    rr.type = wire.types.SOA;
-    rr.ttl = 86400;
-    rr.data = rd;
-
+  //  send SOA-only when we don't have / don't want to answer.
+  async sendSOA() {
     const res = new wire.Message();
-    res.authority.push(rr);
+    res.aa = true;
+    res.authority.push(this.ns.toSOA());
     this.ns.signRRSet(res.authority, wire.types.SOA);
     return res;
   }


### PR DESCRIPTION
Closes #4 

This PR will:
* Hide invalid/unreachable nameservers from recursive
* Use hsd SOA since it has a valid primary NS (MNMAE) and it's authoritative over this data