### PR TITLE
Use the last two labels as the node name

### DIFF
--- a/lib/ethereum.js
+++ b/lib/ethereum.js
@@ -71,7 +71,7 @@ class Ethereum {
 
   async resolveDnsFromEns(name, type, node) {
     if (!node)
-      node = name;
+      node = this.toNode(name);
 
     const resolver = await this.getEnsResolver(this.trimDot(node));
     return this.resolveDnsWithResolver(name, type, node, resolver);
@@ -110,7 +110,7 @@ class Ethereum {
 
   async resolveDnsFromAbstractEns(name, type, ns, node) {
     if (!node)
-      node = name;
+      node = this.toNode(name);
 
     const labels = ns.split('.');
 
@@ -135,7 +135,7 @@ class Ethereum {
 
   async resolveDnsFromRegistry(name, type, registryAddress, node) {
     if (!node)
-      node = name;
+      node = this.toNode(name);
 
     const registry = this.getAbstractEnsRegistry(registryAddress);
     const resolver = await this.getResolverFromRegistry(
@@ -161,6 +161,16 @@ class Ethereum {
       return name.slice(0, -1);
 
     return name;
+  }
+
+  toNode(name) {
+    let node = name
+    const labels = this.trimDot(name).split('.');
+
+    if (labels.length > 1)
+      node = labels.slice(-2).join('.')
+
+    return node
   }
 }
 


### PR DESCRIPTION
Currently, the node (passed to dnsRecord)  is the same as the queried name. 

Example:
```
dig @127.0.0.1 -p 5349 _443._tcp.buffrr.badass tlsa
```

`_443._tcp.buffrr.badass` is used as the node name so it won't return any results because the node is `buffrr.badass`. This PR uses the last two labels as the node name if none specified.