### PR TITLE
Cache ethereum resolver and dnsRecord results

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,6 @@ There's still a lot "TODO":
 Local Ethereum provider: Currently the plugin relies on the Infura API. However,
 it is trivial to add an option to use a local Ethereum full node instead.
 
-Cache: The Ethereum interface should cache "resolver" and "registry" contract
-objects instead of requesting them from the Ethereum provider on each query.
-
 Additional ENS types: This plugin currently only supports resolving of EIP-1185
 data (aka "actual DNS records on ENS") but ENS itself has support for many
 abstract data types like [content hashes](https://eips.ethereum.org/EIPS/eip-1577)

--- a/lib/ethereum.js
+++ b/lib/ethereum.js
@@ -2,6 +2,7 @@
 
 const ethers = require('ethers');
 const {encoding, wire} = require('bns');
+const LRU = require('blru');
 
 const ENS_ADDRESS = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
 const ENS_ABI = [
@@ -26,6 +27,12 @@ const RESOLVER_ABI = [
     'function hasDNSRecords(bytes32 node, bytes32 name) view returns (bool)'
 ];
 
+const CACHE_TTL = 30 * 60 * 1000;
+const CACHE_TAGS = {
+  DNS: 0,
+  RESOLVER: 1
+}
+
 class Ethereum {
   constructor(options) {
     this.keccak256 = ethers.utils.keccak256;
@@ -35,6 +42,7 @@ class Ethereum {
 
     this.ensRegistry = new ethers.Contract(ENS_ADDRESS, ENS_ABI, this.infura);
     this.ensResolver = null;
+    this.cache = new EthereumCache(3000);
   }
 
   async init() {
@@ -42,17 +50,32 @@ class Ethereum {
   }
 
   async getEnsResolver(name) {
-    return this.getResolverFromRegistry(name, this.ensRegistry);
+    return this.getResolver(name, ENS_ADDRESS);
   }
 
-  // TODO: cache these
   async getResolverFromRegistry(name, registry) {
     const resolverAddr = await registry.resolver(this.namehash(name));
     return new ethers.Contract(resolverAddr, RESOLVER_ABI, this.infura);
   }
 
+  async getResolver(name, registryAddress) {
+    const cache = this.cache.getResolver(name, registryAddress);
+    if (cache) {
+      return cache;
+    }
+
+    const registry = this.getAbstractEnsRegistry(registryAddress);
+    const resolver = await this.getResolverFromRegistry(
+      name,
+      registry
+    );
+
+    this.cache.setResolver(name, registryAddress, resolver);
+    return resolver;
+  }
+
   getAbstractEnsRegistry(address) {
-   return new ethers.Contract(address, ENS_ABI, this.infura);
+    return new ethers.Contract(address, ENS_ABI, this.infura);
   }
 
   async resolveEnsAddress(name) {
@@ -78,11 +101,16 @@ class Ethereum {
   }
 
   async resolveDnsWithResolver(name, type, node, resolver) {
-    const record = await resolver.dnsRecord(
-      this.namehash(this.trimDot(node)),
-      this.hashDnsName(name),
-      type
-    );
+    let record = this.cache.getRecord(name, type, resolver.address);
+    if (!record) {
+      record = await resolver.dnsRecord(
+        this.namehash(this.trimDot(node)),
+        this.hashDnsName(name),
+        type
+      );
+
+      this.cache.setRecord(name, type, resolver.address, record);
+    }
 
     if (!record || record === '0x') {
       if (type === wire.types.CNAME || type === wire.types.NS) {
@@ -124,10 +152,9 @@ class Ethereum {
     if (addr.length !== 42)
       return null;
 
-    const registry = await this.getAbstractEnsRegistry(addr);
-    const resolver = await this.getResolverFromRegistry(
+    const resolver = await this.getResolver(
       this.trimDot(node),
-      registry
+      addr
     );
 
     return this.resolveDnsWithResolver(name, type, node, resolver);
@@ -137,18 +164,12 @@ class Ethereum {
     if (!node)
       node = this.toNode(name);
 
-    const registry = this.getAbstractEnsRegistry(registryAddress);
-    const resolver = await this.getResolverFromRegistry(
+    const resolver = await this.getResolver(
       this.trimDot(node),
-      registry
+      registryAddress
     );
-    const record = await resolver.dnsRecord(
-      this.namehash(this.trimDot(node)),
-      this.hashDnsName(name),
-      type
-    );
-    // prefixed with "0x" of course...
-    return Buffer.from(record.substr(2), 'hex');
+
+    return this.resolveDnsWithResolver(name, type, node, resolver);
   }
 
   hashDnsName(name) {
@@ -171,6 +192,83 @@ class Ethereum {
       node = labels.slice(-2).join('.')
 
     return node
+  }
+}
+
+class EthereumCache {
+  constructor(size) {
+    this.cache = new LRU(size);
+  }
+
+  setRecord(name, type, resolverAddress, record) {
+    const key = this.toDnsKey(name, type, resolverAddress);
+
+    if (!record)
+      record = '0x'
+
+    this.cache.set(key, {
+      time: Date.now(),
+      record
+    });
+  }
+
+  getRecord(name, type, resolverAddress) {
+    const key = this.toDnsKey(name, type, resolverAddress);
+    const item = this.cache.get(key);
+
+    if (!item)
+      return null;
+
+    if (Date.now() > item.time + CACHE_TTL)
+      return null;
+
+    return item.record;
+  }
+
+  setResolver(node, registryAddress, resolver) {
+    if (!resolver)
+      return;
+
+    const key = this.toResolverKey(node, registryAddress);
+
+    this.cache.set(key, {
+      time: Date.now(),
+      resolver
+    });
+  }
+
+  getResolver(node, registryAddress) {
+    const key = this.toResolverKey(node, registryAddress);
+    const item = this.cache.get(key);
+
+    if (!item)
+      return null;
+
+    if (Date.now() > item.time + CACHE_TTL)
+      return null;
+
+    return item.resolver;
+  }
+
+  toDnsKey(name, type, resolverAddress) {
+    let key = CACHE_TAGS.DNS.toString() + ';';
+    key += name + ';';
+    key += type.toString() + ';';
+    key += resolverAddress;
+
+    return key;
+  }
+
+  toResolverKey(node, registryAddress) {
+    let key = CACHE_TAGS.RESOLVER.toString() + ';';
+    key += node + ';';
+    key += registryAddress;
+
+    return key;
+  }
+
+  reset() {
+    this.cache.reset();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "peerDependencies": {
     "hsd": "pinheadmz/hsd#dnsplugins1",
-    "bns": "~0.14.0"
+    "bns": "~0.14.0",
+    "blru": "~0.1.6"
   },
   "devDependencies": {
     "bmocha": "^2.1.5"


### PR DESCRIPTION
This helps with reducing requests to Infura/full nodes. Having a lower level cache for dnsRecord also helps with caching the internal CNAME lookups. 