### PR TITLE
Sign .eth records and cnames

### DIFF
--- a/lib/handover.js
+++ b/lib/handover.js
@@ -50,7 +50,10 @@ class Plugin {
             return this.sendSOA();
           } else {
             data = await this.ethereum.resolveDnsFromEns(name, type);
-            return this.sendData(data);
+            if (!data || data.length === 0)
+              return this.sendSOA();
+
+            return this.sendData(data, type);
           }
         case '_eth.':
           return this.sendSOA();
@@ -134,21 +137,9 @@ class Plugin {
       }
 
       // If we did get an answer from Ethereum, mark the response
-      // as authoritative and insert the new answer.
+      // as authoritative and send the new answer.
       this.logger.debug('Returning answers from alternate naming system');
-      const replacementRes = new wire.Message();
-      replacementRes.aa = true;
-      const br = new BufferReader(data);
-      while (br.left() > 0) {
-        replacementRes.answer.push(wire.Record.read(br));
-      }
-
-      // Answers resolved from Ethereum appear to come directly
-      // from the HNS root zone.
-      this.ns.signRRSet(replacementRes.answer, type);
-
-      // Send back the replacement response
-      return replacementRes;
+      return this.sendData(data, type);
     };
   }
 
@@ -203,13 +194,21 @@ class Plugin {
   }
 
   // Convert a wire-format DNS record to a message and send.
-  sendData(data) {
+  sendData(data, type) {
     const res = new wire.Message();
     res.aa = true;
     const br = new BufferReader(data);
     while (br.left() > 0) {
       res.answer.push(wire.Record.read(br));
     }
+
+    // Answers resolved from alternate name systems appear to come directly
+    // from the HNS root zone.
+    this.ns.signRRSet(res.answer, type);
+
+    if (type !== wire.types.CNAME)
+      this.ns.signRRSet(res.answer, wire.types.CNAME);
+
     return res;
   }
 }


### PR DESCRIPTION
This PR signs .eth records and cnames. It seems that we don't sign these:

```
dig @127.0.0.1 -p 5349 fuckingfucker.eth A +dnssec
```

also cnames aren't getting signed since the plugin only signs the lookup type rrset.